### PR TITLE
Add user management APIs and refactor package structure

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -51,9 +51,9 @@
         <!--        OPEN API -->
         <springdoc.version>2.6.0</springdoc.version>
         <!--        SPRING -->
-        <spring-boot.kafka.version>3.3.2</spring-boot.kafka.version>
-        <spring-boot.version>3.4.1</spring-boot.version>
-        <spring-cloud.version>2024.0.0</spring-cloud.version>
+        <spring-boot.kafka.version>3.3.8</spring-boot.kafka.version>
+        <spring-boot.version>3.5.4</spring-boot.version>
+        <spring-cloud.version>2025.0.0</spring-cloud.version>
         <spring-security-aouth2-autoconfigure.version>3.3.2</spring-security-aouth2-autoconfigure.version>
         <spring-cloud-dependencies.version>4.3.0</spring-cloud-dependencies.version>
         <spring-bootstrap.version>4.3.0</spring-bootstrap.version>

--- a/src/main/java/com/umdc/smartkin/SmartKinBackendApplication.java
+++ b/src/main/java/com/umdc/smartkin/SmartKinBackendApplication.java
@@ -4,11 +4,11 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cloud.openfeign.EnableFeignClients;
 
-@EnableFeignClients(basePackages = "com.umdevcreative.smartkin.client")
+@EnableFeignClients(basePackages = "com.umdc.smartkin.client")
 @SpringBootApplication(
         scanBasePackages = {
                 "com.prx.commons.services",
-                "com.umdevcreative.smartkin",
+                "com.umdc.smartkin",
                 "com.prx.security"
         }
 )

--- a/src/main/java/com/umdc/smartkin/api/v1/controller/UserApi.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/controller/UserApi.java
@@ -1,0 +1,115 @@
+package com.umdc.smartkin.api.v1.controller;
+
+import com.umdc.smartkin.api.v1.service.UserService;
+import com.umdc.smartkin.api.v1.to.GetUserResponse;
+import com.umdc.smartkin.api.v1.to.PutUserRequest;
+import com.umdc.smartkin.api.v1.to.UserCreateRequest;
+import com.umdc.smartkin.api.v1.to.UserCreateResponse;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.constraints.NotNull;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.UUID;
+
+import static com.prx.security.constant.ConstantApp.SESSION_TOKEN_KEY;
+
+/// User API interface for handling user-related operations.
+@Tag(name="user", description="The user API")
+public interface UserApi {
+
+    /// Provides an instance of UserService.
+    ///
+    /// @return an instance of UserService
+    default UserService getService() {
+        return new UserService() {};
+    }
+
+    /// Handles the creation of a new user.
+    ///
+    /// @param userCreateRequest the request object containing user creation details
+    /// @return a ResponseEntity containing the response of the user creation operation
+    @Operation(summary = "Create a new user", description = "Creates a new user in the system with the provided details.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "201", description = "User createdAt successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = UserCreateResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content),
+        @ApiResponse(responseCode = "409", description = "Conflict: Alias or email already exists", content = @Content)
+    })
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    default ResponseEntity<UserCreateResponse> createUserPost(@RequestBody UserCreateRequest userCreateRequest) {
+        return this.getService().create(userCreateRequest);
+    }
+
+    /// Handles the retrieval of a user by ID.
+    ///
+    /// @param id the ID of the user to retrieve
+    /// @return a ResponseEntity containing the response of the user retrieval operation
+    /// @see GetUserResponse
+    /// @see ResponseEntity
+    /// @see UUID
+    /// @see UserService
+    /// @see UserApi
+    /// @see UserCreateRequest
+    /// @see UserCreateResponse
+    @Operation(summary = "Get a user by ID", description = "Retrieves a user in the system with the provided ID.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "User retrieved successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = GetUserResponse.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content),
+        @ApiResponse(responseCode = "404", description = "User not found", content = @Content)
+    })
+    @GetMapping(value = "/{id}", produces = MediaType.APPLICATION_JSON_VALUE)
+    default ResponseEntity<GetUserResponse> userGet(
+            @Parameter(description = "Token session", required = true)
+            @RequestHeader(SESSION_TOKEN_KEY) String token,
+            @NotNull @PathVariable UUID id) {
+        return this.getService().findUser(token, id);
+    }
+
+    /// Updates a user by ID.
+    ///
+    /// @param userId the ID of the user to update
+    /// @param request the patch user request
+    /// @return the patch user response
+    @Operation(summary = "Update a user by ID", description = "Updates a user in the system with the provided ID.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "202", description = "User lastUpdate successfully",
+            content = @Content(mediaType = MediaType.APPLICATION_JSON_VALUE,
+                schema = @Schema(implementation = Void.class))),
+        @ApiResponse(responseCode = "400", description = "Invalid request", content = @Content),
+        @ApiResponse(responseCode = "404", description = "User not found", content = @Content)
+    })
+    @PutMapping(value = "/{userId}", consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
+    default ResponseEntity<Void> update(
+            @PathVariable("userId") UUID userId,
+            @RequestBody PutUserRequest request) {
+        return this.getService().update(userId, request);
+    }
+
+    /// Deletes a user by user ID and application ID.
+    ///
+    /// @param userId the ID of the user to delete
+    /// @return a ResponseEntity with appropriate status
+    @Operation(summary = "Delete a user by ID", description = "Deletes a user from the system with the provided user ID. Requires admin or appropriate authorization.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "204", description = "User deleted successfully", content = @Content),
+        @ApiResponse(responseCode = "403", description = "Forbidden: Access denied", content = @Content),
+        @ApiResponse(responseCode = "404", description = "User not found", content = @Content),
+        @ApiResponse(responseCode = "500", description = "Internal server error", content = @Content)
+    })
+    @DeleteMapping(value = "/{userId}")
+    default ResponseEntity<Void> deleteUserByUserId(@NotNull @PathVariable UUID userId) {
+        return this.getService().deleteUserByUserAndApplication(userId);
+    }
+
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/controller/UserController.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/controller/UserController.java
@@ -1,0 +1,65 @@
+package com.umdc.smartkin.api.v1.controller;
+
+import com.umdc.smartkin.api.v1.service.UserService;
+import com.umdc.smartkin.api.v1.to.GetUserResponse;
+import com.umdc.smartkin.api.v1.to.PutUserRequest;
+import com.umdc.smartkin.api.v1.to.UserCreateRequest;
+import com.umdc.smartkin.api.v1.to.UserCreateResponse;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.UUID;
+
+/// REST controller for user-related operations.
+@RestController
+@RequestMapping("/api/v1/users")
+public class UserController implements UserApi {
+
+    private final UserService userService;
+
+    /// Constructs a new UserController with the specified UserService.
+    ///
+    /// @param userService the service used to handle user-related operations
+    public UserController(UserService userService) {
+        this.userService = userService;
+    }
+
+    /// Handles the HTTP POST request to create a new user.
+    ///
+    /// @param userCreateRequest the request object containing user details
+    /// @return a ResponseEntity containing the UserCreateResponse
+    @Override
+    public ResponseEntity<UserCreateResponse> createUserPost(UserCreateRequest userCreateRequest) {
+        return userService.create(userCreateRequest);
+    }
+
+    /// Handles the HTTP GET request to retrieve a user by ID.
+    ///
+    /// @param id the ID of the user to retrieve
+    /// @return a ResponseEntity containing the UseGetResponse
+    @Override
+    public ResponseEntity<GetUserResponse> userGet(String token, UUID id) {
+        return userService.findUser(token, id);
+    }
+
+    /// Handles the HTTP PATCH request to update an existing user.
+    ///
+    /// @param userId the ID of the user to update
+    /// @param request the request object containing the lastUpdate user details
+    /// @return a ResponseEntity containing the PatchUserResponse
+    @Override
+    public ResponseEntity<Void> update(UUID userId, PutUserRequest request) {
+        return userService.update(userId, request);
+    }
+
+    /// Handles the HTTP DELETE request to delete a user by user ID and application ID.
+    ///
+    /// @param userId the ID of the user to delete
+    /// @return a ResponseEntity with appropriate status
+    @Override
+    public ResponseEntity<Void> deleteUserByUserId(UUID userId) {
+        return userService.deleteUserByUserAndApplication(userId);
+    }
+
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/controller/UserRegisterApi.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/controller/UserRegisterApi.java
@@ -1,0 +1,40 @@
+package com.umdc.smartkin.api.v1.controller;
+
+import com.umdc.smartkin.api.v1.service.UserRegisterService;
+import com.umdc.smartkin.api.v1.to.ConfirmCodeRequest;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.responses.ApiResponses;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+
+@Tag(name="user-register", description="The user register API")
+public interface UserRegisterApi {
+
+    /// Get the user register service.
+    ///
+    /// @return the user register service
+    default UserRegisterService getService(){
+        return new UserRegisterService() {};
+    }
+
+    @Operation(summary = "Confirm verification code", description = "Confirms the verification code for the specified user.")
+    @ApiResponses(value = {
+        @ApiResponse(responseCode = "200", description = "Verification code confirmed successfully"),
+        @ApiResponse(responseCode = "400", description = "Invalid request"),
+        @ApiResponse(responseCode = "404", description = "User not found or invalid verification code")
+    })
+    /// Confirms the verification code for the specified user.
+    ///
+    /// @param confirmCodeRequest the request object containing the user ID and verification code
+    /// @return a ResponseEntity containing the response object and HTTP status
+    /// @see ConfirmCodeRequest
+    @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE)
+    default ResponseEntity<Void> confirmCode(@RequestHeader("session-token-bkd") String sessionTokenBkd, @RequestBody ConfirmCodeRequest confirmCodeRequest){
+        return getService().confirmCode(sessionTokenBkd, confirmCodeRequest);
+    }
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/controller/UserRegisterController.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/controller/UserRegisterController.java
@@ -1,0 +1,23 @@
+package com.umdc.smartkin.api.v1.controller;
+
+import com.umdc.smartkin.api.v1.service.UserRegisterService;
+import com.umdc.smartkin.api.v1.to.ConfirmCodeRequest;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/v1/user-register")
+public class UserRegisterController implements UserRegisterApi {
+
+    private final UserRegisterService userRegisterService;
+
+    public UserRegisterController(UserRegisterService userRegisterService) {
+        this.userRegisterService = userRegisterService;
+    }
+
+    @Override
+    public ResponseEntity<Void> confirmCode(String sessionTokenBkd, ConfirmCodeRequest confirmCodeRequest) {
+        return userRegisterService.confirmCode(sessionTokenBkd, confirmCodeRequest);
+    }
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/service/UserRegisterService.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/service/UserRegisterService.java
@@ -1,0 +1,18 @@
+package com.umdc.smartkin.api.v1.service;
+
+import com.umdc.smartkin.api.v1.to.ConfirmCodeRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+/// Service interface for user registration-related operations.
+public interface UserRegisterService {
+
+    /// Confirms the verification code for the specified user.
+    /// @param sessionTokenBkd The Backbone session token
+    /// @param confirmCodeRequest the request object containing the user ID and verification code
+    /// @return a ResponseEntity containing the response object and HTTP status
+    default ResponseEntity<Void> confirmCode(String sessionTokenBkd, ConfirmCodeRequest confirmCodeRequest) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/service/UserRegisterServiceImpl.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/service/UserRegisterServiceImpl.java
@@ -1,0 +1,66 @@
+package com.umdc.smartkin.api.v1.service;
+
+import com.prx.security.to.AuthRequest;
+import com.umdc.smartkin.api.v1.to.ConfirmCodeRequest;
+import com.umdc.smartkin.client.backbone.BackboneClient;
+import com.umdc.smartkin.client.mercury.MercuryClient;
+import com.umdc.smartkin.mapper.ConfirmCodeMapper;
+import feign.FeignException;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+import java.util.UUID;
+
+import static com.umdc.smartkin.constant.SmartKinAppConstants.MESSAGE_HEADER;
+
+
+///  Service implementation for user registration-related operations.
+/// @see UserRegisterService
+/// @see ConfirmCodeRequest
+/// @see ResponseEntity
+/// @see Service
+@Service
+public class UserRegisterServiceImpl implements UserRegisterService {
+
+    @Value("${prx.smartkin.application-id}")
+    private UUID applicationId;
+
+    private final MercuryClient mercuryClient;
+    private final BackboneClient backboneClient;
+    private final ConfirmCodeMapper confirmCodeMapper;
+
+    /// Constructs a new UserRegisterServiceImpl with the specified MercuryClient.
+    ///
+    /// @param mercuryClient the client used to interact with the Mercury service
+    /// @param confirmCodeMapper the mapper used to map confirmation codes
+    /// @see MercuryClient
+    public UserRegisterServiceImpl(MercuryClient mercuryClient, ConfirmCodeMapper confirmCodeMapper, BackboneClient backboneClient) {
+        this.mercuryClient = mercuryClient;
+        this.confirmCodeMapper = confirmCodeMapper;
+        this.backboneClient = backboneClient;
+    }
+
+    /// Confirms the verification code for the specified user.
+    ///
+    /// @param sessionTokenBkd the backbone token session
+    /// @param confirmCodeRequest the request object containing the user ID and verification code
+    /// @return a ResponseEntity containing the response object and HTTP status
+    @Override
+    public ResponseEntity<Void> confirmCode(String sessionTokenBkd, ConfirmCodeRequest confirmCodeRequest) {
+        var userResponse = backboneClient.findUserById(confirmCodeRequest.userId());
+        AuthRequest mercuryAuthRequest = new AuthRequest(userResponse.alias(), userResponse.password());
+        try {
+            var mercuryToken = mercuryClient.token(sessionTokenBkd, mercuryAuthRequest);
+
+            return mercuryClient.confirmCode(mercuryToken.token(),
+                    confirmCodeMapper.toVerificationCodeRequest(confirmCodeRequest, applicationId));
+        } catch (FeignException e) {
+            Optional<String> message = e.responseHeaders().get(MESSAGE_HEADER).stream().findFirst();
+            return ResponseEntity.status(e.status())
+                    .header(MESSAGE_HEADER, message.orElse(""))
+                    .build();
+        }
+    }
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/service/UserService.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/service/UserService.java
@@ -1,0 +1,59 @@
+package com.umdc.smartkin.api.v1.service;
+
+import com.umdc.smartkin.api.v1.to.GetUserResponse;
+import com.umdc.smartkin.api.v1.to.PutUserRequest;
+import com.umdc.smartkin.api.v1.to.UserCreateRequest;
+import com.umdc.smartkin.api.v1.to.UserCreateResponse;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+
+import java.util.UUID;
+
+/// Service interface for user-related operations.
+public interface UserService {
+
+
+    /// Creates a new user.
+    ///
+    /// @param userCreateRequest the request object containing user details
+    /// @return a ResponseEntity containing the response object and HTTP status
+    /// @see UserCreateRequest
+    /// @see UserCreateResponse
+    /// @see ResponseEntity
+    /// @see HttpStatus
+    default ResponseEntity<UserCreateResponse> create(UserCreateRequest userCreateRequest) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    /// Finds a user by ID.
+    ///
+    /// @param id the ID of the user to find
+    /// @return a ResponseEntity containing the response object and HTTP status
+    /// @see GetUserResponse
+    /// @see ResponseEntity
+    /// @see HttpStatus
+    /// @see UUID
+    default ResponseEntity<GetUserResponse> findUser(String token, UUID id) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    /// Updates a user by ID.
+    ///
+    /// @param userId the ID of the user to update
+    /// @param request the patch user request
+    /// @return a ResponseEntity containing the patch user response
+    default ResponseEntity<Void> update(UUID userId, PutUserRequest request) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+    /// Deletes a user by user ID and application ID.
+    ///
+    /// @param userId the ID of the user to delete
+    /// @return a ResponseEntity with appropriate status
+    /// @see ResponseEntity
+    /// @see UUID
+    default ResponseEntity<Void> deleteUserByUserAndApplication(UUID userId) {
+        return new ResponseEntity<>(HttpStatus.NOT_IMPLEMENTED);
+    }
+
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/service/UserServiceImpl.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/service/UserServiceImpl.java
@@ -326,7 +326,7 @@ public class UserServiceImpl implements UserService {
         String fullname = userCreateRequest.firstname().concat(" ").concat(userCreateRequest.lastname());
         return new EmailMessageTO(verificationCodeTemplateId,
                 userCreateResponse.id(),
-                "support@latinhub.info",
+                supportEmail,
                 List.of(new Recipient(
                         fullname,
                         userCreateResponse.email(),

--- a/src/main/java/com/umdc/smartkin/api/v1/service/UserServiceImpl.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/service/UserServiceImpl.java
@@ -1,0 +1,347 @@
+package com.umdc.smartkin.api.v1.service;
+
+import com.prx.commons.constants.httpstatus.type.MessageType;
+import com.prx.commons.exception.StandardException;
+import com.umdc.smartkin.api.v1.to.GetUserResponse;
+import com.umdc.smartkin.api.v1.to.PutUserRequest;
+import com.umdc.smartkin.api.v1.to.UserCreateRequest;
+import com.umdc.smartkin.api.v1.to.UserCreateResponse;
+import com.umdc.smartkin.client.backbone.BackboneClient;
+import com.umdc.smartkin.client.backbone.to.BackboneUserUpdateRequest;
+import com.umdc.smartkin.kafka.producer.EmailMessageProducerService;
+import com.umdc.smartkin.kafka.to.EmailMessageTO;
+import com.umdc.smartkin.kafka.to.Recipient;
+import com.umdc.smartkin.mapper.GetUserMapper;
+import com.umdc.smartkin.mapper.PutUserMapper;
+import com.umdc.smartkin.mapper.UserCreateMapper;
+import feign.FeignException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+
+import java.security.SecureRandom;
+import java.util.*;
+
+import static com.umdc.smartkin.constant.SmartKinAppConstants.*;
+import static org.springframework.http.HttpStatus.BAD_REQUEST;
+
+/// Service implementation for user-related operations.
+@Service
+public class UserServiceImpl implements UserService {
+
+    private static final Logger logger = LoggerFactory.getLogger(UserServiceImpl.class);
+    private static final String USERNAME_ALREADY_EXISTS = "Username {} already exists";
+    private static final String EMAIL_ALREADY_EXISTS = "Email already exists";
+    private static final String ERROR_CREATING_USER = "Error creating user";
+    private static final int MAX_ALIAS_LENGTH = 12;
+    private static final int MAX_ALIAS_TRY = 5;
+
+    @Value("${prx.verification.code.template.id}")
+    private UUID verificationCodeTemplateId;
+    @Value("${prx.smartkin.application-id}")
+    private String applicationIdString;
+    @Value("${prx.smartkin.role-id}")
+    private String initialRoleId;
+
+    private final EmailMessageProducerService emailMessageProducerService;
+    private final UserCreateMapper userCreateMapper;
+    private final PutUserMapper putUserMapper;
+    private final BackboneClient backboneClient;
+    private final GetUserMapper getUserMapper;
+
+    /// Constructs a new UserServiceImpl with the specified BackboneClient and UserCreateMapper.
+    ///
+    /// @param backboneClient   the client used to communicate with the backend
+    /// @param userCreateMapper the mapper used to convert between request/response objects and backend objects
+    public UserServiceImpl(BackboneClient backboneClient, EmailMessageProducerService emailMessageProducerService,
+                           UserCreateMapper userCreateMapper, PutUserMapper putUserMapper,
+                           GetUserMapper getUserMapper) {
+        this.emailMessageProducerService = emailMessageProducerService;
+        this.userCreateMapper = userCreateMapper;
+        this.backboneClient = backboneClient;
+        this.putUserMapper = putUserMapper;
+        this.getUserMapper = getUserMapper;
+    }
+
+    @Override
+    public ResponseEntity<UserCreateResponse> create(UserCreateRequest userCreateRequest) {
+        logger.debug("Creating user: {}", userCreateRequest);
+        UUID applicationID = UUID.fromString(applicationIdString);
+        try {
+            if (Objects.isNull(userCreateRequest)) {
+                logger.warn("Content null invalid");
+                return ResponseEntity.status(BAD_REQUEST).header(MESSAGE_ERROR_HEADER, "Content null invalid").build();
+            }
+            backboneClient.checkEmail(userCreateRequest.email(), applicationID);
+            var backboneUserCreateRequest = userCreateMapper.toBackbone(userCreateRequest,
+                    applicationID, UUID.fromString(initialRoleId), generateAlias(userCreateRequest, true, 1));
+            logger.debug("Creating user: {}", backboneUserCreateRequest);
+            var userCreateResponse = userCreateMapper.fromBackbone(backboneClient.post(backboneUserCreateRequest));
+            emailMessageProducerService.sendMessage(toEmailMessageTO(userCreateRequest, userCreateResponse));
+            return ResponseEntity.status(HttpStatus.CREATED).body(userCreateResponse);
+        } catch (FeignException e) {
+            logger.warn("Error creating user: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.CONFLICT).header(MESSAGE_ERROR_HEADER, EMAIL_ALREADY_EXISTS).build();
+        } catch (StandardException e) {
+            logger.warn("Standard Error creating user: {}", e.getMessage());
+            return ResponseEntity.status(HttpStatus.CONFLICT).header(MESSAGE_ERROR_HEADER, ERROR_CREATING_USER).build();
+        }
+    }
+
+    @Override
+    public ResponseEntity<GetUserResponse> findUser(String token, UUID id) {
+        try {
+            UUID applicationID = UUID.fromString(applicationIdString);
+            var result = backboneClient.findUserById(id);
+            final var profileRef = getString(token, applicationID);
+            return ResponseEntity.ok(getUserMapper.fromBackbone(result, profileRef));
+        } catch (FeignException e) {
+            logger.warn("Error finding user: {}", e.getMessage());
+            if (e.status() == HttpStatus.NOT_FOUND.value()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND).header("message-error", USER_NOT_FOUND_MESSAGE).build();
+            }
+            return ResponseEntity.status(e.status()).build();
+        }
+    }
+
+    private String getString(String token, UUID applicationID) {
+        try {
+            var profileImageRef = backboneClient.getProfileImageRef(token, applicationID);
+            return Objects.nonNull(profileImageRef.getBody()) && Objects.nonNull(profileImageRef.getBody().ref()) ?
+                    profileImageRef.getBody().ref() : "";
+        } catch (FeignException e) {
+            if (e.status() == HttpStatus.NOT_FOUND.value()) {
+                return "";
+            }
+        }
+        return "";
+    }
+
+    @Override
+    public ResponseEntity<Void> update(UUID userId, PutUserRequest request) {
+        try {
+            // Validate request object
+            if (Objects.isNull(request)) {
+                logger.warn("Update request is null for user: {}", userId);
+                return ResponseEntity.status(BAD_REQUEST)
+                        .header(MESSAGE_HEADER, "Request body is missing.")
+                        .build();
+            }
+
+            // Validate user ID
+            if (Objects.isNull(userId)) {
+                logger.warn("User ID is null");
+                return ResponseEntity.status(BAD_REQUEST)
+                        .header(MESSAGE_HEADER, "User ID is required.")
+                        .build();
+            }
+
+            // Validate role IDs if provided
+            if (request.roleIds() != null) {
+                ResponseEntity<Void> roleValidation = validateRoleIds(request.roleIds());
+                if (roleValidation != null) {
+                    return roleValidation;
+                }
+            }
+
+            // Check if user exists before updating
+            try {
+                var existingUser = backboneClient.findUserById(userId);
+                if (existingUser == null) {
+                    logger.warn("User not found: {}", userId);
+                    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                            .header(MESSAGE_HEADER, USER_NOT_FOUND_MESSAGE)
+                            .build();
+                }
+            } catch (FeignException e) {
+                if (e.status() == HttpStatus.NOT_FOUND.value()) {
+                    logger.warn("User not found: {}", userId);
+                    return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                            .header(MESSAGE_HEADER, USER_NOT_FOUND_MESSAGE)
+                            .build();
+                }
+                throw e;
+            }
+
+            BackboneUserUpdateRequest backboneRequest = putUserMapper.toBackbone(UUID.fromString(applicationIdString), request);
+            logger.info("Updating user: {} with request: {}", userId, backboneRequest);
+            return backboneClient.userPartialUpdate(userId, backboneRequest);
+        } catch (FeignException e) {
+            logger.warn("Feign exception while updating user {}: {}", userId, e.getMessage());
+            if (e.status() == HttpStatus.NOT_FOUND.value()) {
+                return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                        .header(MESSAGE_HEADER, USER_NOT_FOUND_MESSAGE)
+                        .build();
+            } else if (e.status() == BAD_REQUEST.value()) {
+                return ResponseEntity.status(BAD_REQUEST)
+                        .header(MESSAGE_HEADER, "Invalid request data.")
+                        .build();
+            }
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .header(MESSAGE_HEADER, "Error updating user.")
+                    .build();
+        } catch (Exception e) {
+            logger.error("Unexpected error updating user {}: {}", userId, e.getMessage(), e);
+            return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                    .header(MESSAGE_HEADER, "An unexpected error occurred while updating the user.")
+                    .build();
+        }
+    }
+
+    /**
+     * Deletes a user by user ID and application ID using the BackboneClient.
+     *
+     * @param userId the ID of the user to delete
+     * @return a ResponseEntity with appropriate status
+     */
+    @Override
+    public ResponseEntity<Void> deleteUserByUserAndApplication(UUID userId) {
+        var applicationId = UUID.fromString(applicationIdString);
+        logger.info("Attempting to delete user with ID: {} for application: {}", userId, applicationId);
+
+        try {
+            // Call the BackboneClient to delete the user
+            ResponseEntity<Void> response = backboneClient.deleteUserByUserIdAndApplicationId(applicationId, userId);
+
+            if (response.getStatusCode().equals(HttpStatus.NO_CONTENT)) {
+                logger.info("Successfully deleted user with ID: {} for application: {}", userId, applicationId);
+                return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+            }
+        } catch (FeignException e) {
+            if (e.status() == HttpStatus.NOT_FOUND.value()) {
+                logger.warn("User with ID {} not found for deletion in application: {}", userId, applicationId);
+                return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+            }
+            if (e.status() == HttpStatus.FORBIDDEN.value()) {
+                logger.warn("Access denied for deleting user with ID: {} in application: {}", userId, applicationId);
+                return new ResponseEntity<>(HttpStatus.FORBIDDEN);
+            }
+            if (e.status() == BAD_REQUEST.value()) {
+                logger.warn("Invalid request data for deletion in application: {}", applicationId);
+                return new ResponseEntity<>(BAD_REQUEST);
+            }
+            logger.error("Unexpected response status: {} when deleting user with ID: {} for application: {}",
+                    e.status(), userId, applicationId);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        } catch (Exception e) {
+            logger.warn("Error deleting user with ID: {} for application: {}", userId, applicationId, e);
+            return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+        }
+        return new ResponseEntity<>(HttpStatus.NOT_MODIFIED);
+    }
+
+    /**
+     * Validates role IDs for edge cases.
+     *
+     * @param roleIds the collection of role IDs to validate
+     * @return ResponseEntity with error details if validation fails, null if validation passes
+     */
+    private ResponseEntity<Void> validateRoleIds(List<UUID> roleIds) {
+        // Check for empty collection (removing all roles)
+        if (roleIds.isEmpty()) {
+            logger.warn("Attempting to remove all roles from user");
+            return ResponseEntity.status(BAD_REQUEST)
+                    .header(MESSAGE_HEADER, "Cannot remove all roles from user. At least one role is required.")
+                    .build();
+        }
+
+        // Check for null role IDs
+        if (roleIds.stream().anyMatch(Objects::isNull)) {
+            logger.warn("Role collection contains null values");
+            return ResponseEntity.status(BAD_REQUEST)
+                    .header(MESSAGE_HEADER, "Role collection contains invalid null values.")
+                    .build();
+        }
+
+        // Check for duplicate role IDs
+        if (roleIds.size() != roleIds.stream().distinct().count()) {
+            logger.warn("Role collection contains duplicate values");
+            return ResponseEntity.status(BAD_REQUEST)
+                    .header(MESSAGE_HEADER, "Role collection contains duplicate values.")
+                    .build();
+        }
+
+        // Check for invalid/empty UUIDs
+        for (UUID roleId : roleIds) {
+            if (roleId.toString().equals("00000000-0000-0000-0000-000000000000")) {
+                logger.warn("Role collection contains invalid UUID: {}", roleId);
+                return ResponseEntity.status(BAD_REQUEST)
+                        .header(MESSAGE_HEADER, "Role collection contains invalid role ID.")
+                        .build();
+            }
+        }
+
+        return null; // Validation passed
+    }
+
+    /// Generates a random four-digit number.
+    ///
+    /// This method uses [SecureRandom] to generate a random integer between 1000 and 9999 (inclusive), ensuring
+    /// that the result is always a four-digit number. This can be used for purposes such as verification codes or temporary PINs.
+    ///
+    /// @return a random four-digit integer between 1000 and 9999
+    public int generateFourDigitNumber() {
+        SecureRandom random = new SecureRandom();
+        return 1000 + random.nextInt(9000); // Generates a number from 1000 to 9999
+    }
+
+    private String generateAlias(UserCreateRequest userCreateRequest, boolean afterFirstTime, int time) {
+        SecureRandom random = new SecureRandom();
+        String alias;
+        StringBuilder aliasTemp = new StringBuilder(userCreateRequest.firstname().substring(0, 1)
+                .concat(userCreateRequest.lastname()));
+
+        random.nextBytes(new byte[20]);
+        if (afterFirstTime) {
+            if (aliasTemp.length() >= MAX_ALIAS_LENGTH) {
+                aliasTemp.delete(MAX_ALIAS_LENGTH - 5, MAX_ALIAS_LENGTH);
+            }
+            aliasTemp.append(random.nextInt());
+        }
+        alias = fixAlias(aliasTemp);
+        try {
+            backboneClient.checkAlias(alias, UUID.fromString(applicationIdString));
+            return alias.toLowerCase(Locale.ROOT);
+        } catch (FeignException e) {
+            logger.warn(USERNAME_ALREADY_EXISTS, alias);
+        }
+
+        if (time <= MAX_ALIAS_TRY) {
+            return generateAlias(userCreateRequest, false, time + 1);
+        }
+        throw new StandardException("Alias generation failed", MessageType.DEFAULT_MESSAGE);
+    }
+
+    private String fixAlias(StringBuilder alias) {
+        if (alias.length() >= MAX_ALIAS_LENGTH) {
+            return alias.substring(0, MAX_ALIAS_LENGTH - 1);
+        }
+        return alias.toString();
+    }
+
+    private EmailMessageTO toEmailMessageTO(UserCreateRequest userCreateRequest, UserCreateResponse userCreateResponse) {
+        String fullname = userCreateRequest.firstname().concat(" ").concat(userCreateRequest.lastname());
+        return new EmailMessageTO(verificationCodeTemplateId,
+                userCreateResponse.id(),
+                "support@latinhub.info",
+                List.of(new Recipient(
+                        fullname,
+                        userCreateResponse.email(),
+                        userCreateRequest.firstname())),
+                Collections.emptyList(),
+                "Verification Code subscription",
+                "Your verification code format is: ####-####",
+                userCreateResponse.createdDate(),
+                Map.of("vc", generateVerificationCode(), "user_name", fullname)
+        );
+    }
+
+    private String generateVerificationCode() {
+        // Implement your code generation logic here
+        return generateFourDigitNumber() +
+                "-" + generateFourDigitNumber();
+    }
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/to/ConfirmCodeRequest.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/to/ConfirmCodeRequest.java
@@ -1,0 +1,13 @@
+package com.umdc.smartkin.api.v1.to;
+
+import java.util.UUID;
+
+public record ConfirmCodeRequest(UUID userId, String verificationCode) {
+    @Override
+    public String toString() {
+        return "ConfirmCodeRequest{" +
+                "userId=" + userId +
+                ", verificationCode='" + verificationCode + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/to/GetUserResponse.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/to/GetUserResponse.java
@@ -1,0 +1,62 @@
+package com.umdc.smartkin.api.v1.to;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.prx.commons.util.DateUtil;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.Set;
+import java.util.UUID;
+
+/// Represents the response object for a user get operation.
+public record GetUserResponse(
+        UUID id,
+        String alias,
+        String email,
+        String firstName,
+        String middleName,
+        String lastName,
+        String displayName,
+        String profileImageRef,
+        UUID phoneId,
+        String phoneNumber,
+        Set<UUID> businessIds,
+        @JsonFormat(pattern = DateUtil.PATTERN_DATE)
+        LocalDate dateOfBirth,
+        @JsonFormat(pattern = DateUtil.PATTERN_DATE_TIME)
+        LocalDateTime createdAt,
+        @JsonFormat(pattern = DateUtil.PATTERN_DATE_TIME)
+        LocalDateTime updatedAt,
+        boolean notificationEmail,
+        boolean notificationSms,
+        boolean privacyDataOutActive,
+        boolean status,
+        UUID roleId,
+        UUID applicationId) {
+
+    /// String representation of the UseGetResponse object.
+    @Override
+    public String toString() {
+        return "UseGetResponse{" +
+                "id=" + id +
+                ", alias='" + alias + '\'' +
+                ", email='" + email + '\'' +
+                ", firstName='" + firstName + '\'' +
+                ", middleName='" + middleName + '\'' +
+                ", lastName='" + lastName + '\'' +
+                ", displayName='" + displayName + '\'' +
+                ", profileImageRef='" + profileImageRef + '\'' +
+                ", phoneId=" + phoneId +
+                ", phoneNumber='" + phoneNumber + '\'' +
+                ", dateOfBirth=" + dateOfBirth +
+                ", createdAt=" + createdAt +
+                ", updatedAt=" + updatedAt +
+                ", notificationEmail=" + notificationEmail +
+                ", notificationSms=" + notificationSms +
+                ", privacyDataOutActive=" + privacyDataOutActive +
+                ", status='" + status + '\'' +
+                ", roleIds=" + roleId +
+                ", applicationId=" + applicationId +
+                '}';
+    }
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/to/PutUserRequest.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/to/PutUserRequest.java
@@ -1,0 +1,34 @@
+package com.umdc.smartkin.api.v1.to;
+
+import java.util.List;
+import java.util.UUID;
+
+/// PutUserRequest record.
+///
+/// Represents a request to update a user's information in the system. This record encapsulates all fields that can be lastUpdate for a user.
+///
+/// Fields:
+///   - **firstName**: The user's first name.
+///   - **lastName**: The user's last name.
+///   - **displayName**: The display name for the user.
+///   - **notificationEmail**: Whether email notifications are enabled for the user.
+///   - **notificationSms**: Whether SMS notifications are enabled for the user.
+///   - **privacyDataOutActive**: Whether the user's privacy data out is active.
+///   - **phoneId**: The unique identifier for the user's phoneNumber.
+///   - **phoneNumber**: The user's phoneNumber number.
+///   - **roleIds**: The collection of unique identifiers for the user's roles.
+///   - **active**: Whether the user is currently active.
+///
+public record PutUserRequest(
+        String firstName,
+        String lastName,
+        String displayName,
+        Boolean notificationEmail,
+        Boolean notificationSms,
+        Boolean privacyDataOutActive,
+        UUID phoneId,
+        String phoneNumber,
+        List<UUID> roleIds,
+        Boolean active
+) {
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/to/UserCreateRequest.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/to/UserCreateRequest.java
@@ -1,0 +1,63 @@
+package com.umdc.smartkin.api.v1.to;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.prx.commons.util.DateUtil;
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
+
+import java.time.LocalDate;
+
+/// UserCreateRequest record.
+///
+/// Represents a request object for creating a new user in the system. This record encapsulates all the necessary fields required for user registration, including personal information, contact details, and notification preferences.
+///
+///
+///     - **password**: The user's password. Must not be blank.
+///     - **email**: The user's email address. Must not be blank and must be a valid email format.
+///     - **firstname**: The user's first name. Must not be blank.
+///     - **lastname**: The user's last name. Must not be blank.
+///     - **dateOfBirth**: The user's date of birth. Must not be empty and must follow the pattern defined in [#PATTERN_DATE].
+///     - **phoneNumber**: The user's phoneNumber number. Must not be blank.
+///     - **displayName**: The display name for the user (optional).
+///     - **notificationSms**: Indicates if SMS notifications are enabled for the user (optional).
+///     - **notificationEmail**: Indicates if email notifications are enabled for the user (optional).
+///     - **privacyDataOutActive**: Indicates if the user's privacy data out is active (optional).
+///
+@JsonIgnoreProperties(ignoreUnknown = true)
+public record UserCreateRequest(
+        @NotBlank
+        String password,
+        @NotBlank @Email
+        String email,
+        @NotBlank
+        String firstname,
+        @NotBlank
+        String lastname,
+        @NotEmpty @JsonFormat(pattern = DateUtil.PATTERN_DATE)
+        LocalDate dateOfBirth,
+        @NotBlank
+        String phoneNumber,
+        String displayName,
+        Boolean notificationSms,
+        Boolean notificationEmail,
+        Boolean privacyDataOutActive
+) {
+
+    @Override
+    public String toString() {
+        return "UserCreateRequest{" +
+                ", password='" + password + '\'' +
+                ", email='" + email + '\'' +
+                ", firstname='" + firstname + '\'' +
+                ", lastname='" + lastname + '\'' +
+                ", dateOfBirth=" + dateOfBirth +
+                ", phoneNumber='" + phoneNumber + '\'' +
+                ", displayName='" + displayName + '\'' +
+                ", notificationSms=" + notificationSms +
+                ", notificationEmail=" + notificationEmail +
+                ", privacyDataOutActive=" + privacyDataOutActive +
+                '}';
+    }
+}

--- a/src/main/java/com/umdc/smartkin/api/v1/to/UserCreateResponse.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/to/UserCreateResponse.java
@@ -1,0 +1,64 @@
+package com.umdc.smartkin.api.v1.to;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.prx.commons.util.DateUtil;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDateTime;
+import java.util.UUID;
+
+/// UserCreateResponse record.
+///
+/// Represents the response object returned after successfully creating a user. This record contains all relevant user information as stored in the system after creation.
+///
+///
+///     - **id**: The unique identifier for the user.
+///     - **alias**: The user's alias or username.
+///     - **email**: The user's email address.
+///     - **createdDate**: The date and time when the user was createdAt.
+///     - **lastUpdate**: The date and time when the user was last lastUpdate.
+///     - **active**: Indicates if the user is currently active.
+///     - **personId**: The unique identifier of the associated person entity.
+///     - **roleIds**: The unique identifier of the user's role.
+///     - **applicationId**: The unique identifier of the application associated with the user.
+///     - **displayName**: The display name for the user.
+///     - **notificationSms**: Indicates if SMS notifications are enabled for the user.
+///     - **notificationEmail**: Indicates if email notifications are enabled for the user.
+///     - **privacyDataOutActive**: Indicates if the user's privacy data out is active.
+///
+public record UserCreateResponse(
+        UUID id,
+        String alias,
+        String email,
+        @NotNull @JsonFormat(pattern = DateUtil.PATTERN_DATE_TIME_MIL)
+        LocalDateTime createdDate,
+        @NotNull @JsonFormat(pattern = DateUtil.PATTERN_DATE_TIME_MIL)
+        LocalDateTime lastUpdate,
+        boolean active,
+        UUID personId,
+        UUID roleId,
+        UUID applicationId,
+        String displayName,
+        Boolean notificationSms,
+        Boolean notificationEmail,
+        Boolean privacyDataOutActive) {
+
+    @Override
+    public String toString() {
+        return "UserCreateResponse{" +
+                "id=" + id +
+                ", alias='" + alias + '\'' +
+                ", email='" + email + '\'' +
+                ", createdDate=" + createdDate +
+                ", lastUpdate=" + lastUpdate +
+                ", active=" + active +
+                ", personId=" + personId +
+                ", roleIds=" + roleId +
+                ", applicationId=" + applicationId +
+                ", displayName='" + displayName + '\'' +
+                ", notificationSms=" + notificationSms +
+                ", notificationEmail=" + notificationEmail +
+                ", privacyDataOutActive=" + privacyDataOutActive +
+                '}';
+    }
+}

--- a/src/main/java/com/umdc/smartkin/constant/SmartKinAppConstants.java
+++ b/src/main/java/com/umdc/smartkin/constant/SmartKinAppConstants.java
@@ -8,7 +8,7 @@ package com.umdc.smartkin.constant;
  * This class cannot be instantiated.
  */
 public final class SmartKinAppConstants {
-    public static final String ENTITY_PACKAGE = "com.umdc.smartkin.jpa.entity";
+    public static final String ENTITY_PACKAGE = "com.umdc.smartkin.jpa.domain";
     public static final String REPOSITORY_PACKAGE = "com.umdc.smartkin.jpa.repository";
     public static final String MESSAGE_ERROR_HEADER = "message-error";
     public static final String MESSAGE_HEADER = "message";

--- a/src/main/java/com/umdc/smartkin/jpa/domain/AchievementEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/AchievementEntity.java
@@ -50,6 +50,10 @@ public class AchievementEntity {
     @Column(name = "requirements", nullable = false, length = Integer.MAX_VALUE)
     private String requirements;
 
+    public AchievementEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }
@@ -98,10 +102,4 @@ public class AchievementEntity {
         this.requirements = requirements;
     }
 
-/*
- TODO [Reverse Engineering] create field to map the 'difficulty' column
- Available actions: Define target Java type | Uncomment as is | Remove column mapping
-    @Column(name = "difficulty", columnDefinition = "achievement_difficulty not null")
-    private Object difficulty;
-*/
 }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/ActivityEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/ActivityEntity.java
@@ -70,6 +70,10 @@ public class ActivityEntity {
     @Column(name = "is_active", nullable = false)
     private Boolean isActive = false;
 
+    public ActivityEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }
@@ -150,10 +154,4 @@ public class ActivityEntity {
         this.isActive = isActive;
     }
 
-/*
- TODO [Reverse Engineering] create field to map the 'difficulty_level' column
- Available actions: Define target Java type | Uncomment as is | Remove column mapping
-    @Column(name = "difficulty_level", columnDefinition = "difficulty_level not null")
-    private Object difficultyLevel;
-*/
 }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/ActivityProgressEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/ActivityProgressEntity.java
@@ -54,6 +54,10 @@ public class ActivityProgressEntity {
     @Column(name = "parent_feedback", length = Integer.MAX_VALUE)
     private String parentFeedback;
 
+    public ActivityProgressEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/AssignedActivityEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/AssignedActivityEntity.java
@@ -54,6 +54,10 @@ public class AssignedActivityEntity {
     @Column(name = "due_date")
     private Instant dueDate;
 
+    public AssignedActivityEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }
@@ -102,11 +106,4 @@ public class AssignedActivityEntity {
         this.dueDate = dueDate;
     }
 
-/*
- TODO [Reverse Engineering] create field to map the 'status' column
- Available actions: Define target Java type | Uncomment as is | Remove column mapping
-    @ColumnDefault("'assigned'")
-    @Column(name = "status", columnDefinition = "activity_status not null")
-    private Object status;
-*/
 }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/ChildAchievementEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/ChildAchievementEntity.java
@@ -45,6 +45,10 @@ public class ChildAchievementEntity {
     @Column(name = "earned_at", nullable = false)
     private Instant earnedAt;
 
+    public ChildAchievementEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/ChildEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/ChildEntity.java
@@ -50,6 +50,10 @@ public class ChildEntity {
     @Column(name = "total_points", nullable = false)
     private Integer totalPoints;
 
+    public ChildEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/ChildRewardEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/ChildRewardEntity.java
@@ -34,6 +34,10 @@ public class ChildRewardEntity {
     @Column(name = "redeemed_at", nullable = false)
     private Instant redeemedAt;
 
+    public ChildRewardEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/GoalEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/GoalEntity.java
@@ -65,6 +65,10 @@ public class GoalEntity {
     @JoinColumn(name = "reward_id")
     private RewardEntity reward;
 
+    public GoalEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/NotificationEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/NotificationEntity.java
@@ -45,6 +45,10 @@ public class NotificationEntity {
     @Column(name = "is_read", nullable = false)
     private Boolean isRead = false;
 
+    public NotificationEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/ParentEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/ParentEntity.java
@@ -28,6 +28,10 @@ public class ParentEntity {
     @Column(name = "profile_picture")
     private String profilePicture;
 
+    public ParentEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/PointEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/PointEntity.java
@@ -12,7 +12,7 @@ import java.util.UUID;
 
 @Entity
 @Table(name = "points", schema = "smartkin")
-public class Point {
+public class PointEntity {
     @Id
     @ColumnDefault("smartkin.uuid_generate_v4()")
     @Column(name = "point_id", nullable = false)
@@ -43,6 +43,10 @@ public class Point {
     private Instant transactionDate;
     @Column(name = "description", length = Integer.MAX_VALUE)
     private String description;
+
+    public PointEntity() {
+        // Default constructor
+    }
 
     public UUID getId() {
         return id;

--- a/src/main/java/com/umdc/smartkin/jpa/domain/RewardEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/RewardEntity.java
@@ -40,6 +40,10 @@ public class RewardEntity {
     @Column(name = "is_digital", nullable = false)
     private Boolean isDigital = false;
 
+    public RewardEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/TopicEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/TopicEntity.java
@@ -36,6 +36,10 @@ public class TopicEntity {
     @Column(name = "age_range_max")
     private Integer ageRangeMax;
 
+    public TopicEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/umdc/smartkin/jpa/domain/UserEntity.java
+++ b/src/main/java/com/umdc/smartkin/jpa/domain/UserEntity.java
@@ -21,6 +21,10 @@ public class UserEntity {
     @Column(name = "id", nullable = false)
     private UUID id;
 
+    public UserEntity() {
+        // Default constructor
+    }
+
     public UUID getId() {
         return id;
     }

--- a/src/main/java/com/umdc/smartkin/jpa/repository/PointRepository.java
+++ b/src/main/java/com/umdc/smartkin/jpa/repository/PointRepository.java
@@ -1,10 +1,10 @@
 package com.umdc.smartkin.jpa.repository;
 
-import com.umdc.smartkin.jpa.domain.Point;
+import com.umdc.smartkin.jpa.domain.PointEntity;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 import java.util.UUID;
 
-public interface PointRepository extends JpaRepository<Point, UUID> {
+public interface PointRepository extends JpaRepository<PointEntity, UUID> {
 }
 

--- a/src/main/java/com/umdc/smartkin/kafka/config/KafkaProducerConfig.java
+++ b/src/main/java/com/umdc/smartkin/kafka/config/KafkaProducerConfig.java
@@ -1,0 +1,46 @@
+package com.umdc.smartkin.kafka.config;
+
+import io.jsonwebtoken.lang.Objects;
+import org.apache.kafka.clients.producer.ProducerConfig;
+import org.apache.kafka.common.serialization.StringSerializer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.DefaultKafkaProducerFactory;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.core.ProducerFactory;
+
+import java.util.HashMap;
+import java.util.Map;
+
+@Configuration
+public class KafkaProducerConfig {
+
+    private static final Logger logger = LoggerFactory.getLogger(KafkaProducerConfig.class);
+
+    @Value("${prx.bootstrap.server.url}")
+    private String bootstrapServers;
+
+    @Value("${prx.bootstrap.server.port}")
+    private String bootstrapServerPort;
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+        logger.info("Creating Producer Factory");
+        Map<String, Object> configProps = new HashMap<>();
+        configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
+                !Objects.isEmpty(bootstrapServerPort) ? bootstrapServers+":"+bootstrapServerPort : bootstrapServers);
+        configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
+        logger.info("Producer Factory created");
+        return new DefaultKafkaProducerFactory<>(configProps);
+    }
+
+    @Bean
+    public KafkaTemplate<String, String> kafkaTemplate() {
+        logger.info("Creating Kafka Template");
+        return new KafkaTemplate<>(producerFactory());
+    }
+}

--- a/src/main/java/com/umdc/smartkin/kafka/config/KafkaProducerConfig.java
+++ b/src/main/java/com/umdc/smartkin/kafka/config/KafkaProducerConfig.java
@@ -31,7 +31,7 @@ public class KafkaProducerConfig {
         logger.info("Creating Producer Factory");
         Map<String, Object> configProps = new HashMap<>();
         configProps.put(ProducerConfig.BOOTSTRAP_SERVERS_CONFIG,
-                !Objects.isEmpty(bootstrapServerPort) ? bootstrapServers+":"+bootstrapServerPort : bootstrapServers);
+                !Objects.isEmpty(bootstrapServerPort) ? String.format("%s:%s", bootstrapServers, bootstrapServerPort) : bootstrapServers);
         configProps.put(ProducerConfig.KEY_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         configProps.put(ProducerConfig.VALUE_SERIALIZER_CLASS_CONFIG, StringSerializer.class);
         logger.info("Producer Factory created");

--- a/src/main/java/com/umdc/smartkin/kafka/producer/EmailMessageProducerService.java
+++ b/src/main/java/com/umdc/smartkin/kafka/producer/EmailMessageProducerService.java
@@ -1,0 +1,12 @@
+package com.umdc.smartkin.kafka.producer;
+
+import com.umdc.smartkin.kafka.to.EmailMessageTO;
+import org.springframework.http.HttpStatus;
+
+public interface EmailMessageProducerService {
+
+
+    default void sendMessage(EmailMessageTO emailMessageTO) {
+        throw new UnsupportedOperationException(HttpStatus.NOT_IMPLEMENTED.getReasonPhrase());
+    }
+}

--- a/src/main/java/com/umdc/smartkin/kafka/producer/EmailMessageProducerServiceImpl.java
+++ b/src/main/java/com/umdc/smartkin/kafka/producer/EmailMessageProducerServiceImpl.java
@@ -1,0 +1,51 @@
+package com.umdc.smartkin.kafka.producer;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.prx.commons.constants.httpstatus.type.MessageType;
+import com.prx.commons.exception.StandardException;
+import com.umdc.smartkin.kafka.to.EmailMessageTO;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.support.SendResult;
+import org.springframework.stereotype.Service;
+
+import java.util.concurrent.CompletableFuture;
+
+@Service
+public class EmailMessageProducerServiceImpl implements EmailMessageProducerService {
+
+    private final KafkaTemplate<String, String> kafkaTemplate;
+    private final ObjectMapper objectMapper;
+
+    @Value("${prx.producer.mercury.topic}")
+    private String topic;
+
+    private static final Logger logger = LoggerFactory.getLogger(EmailMessageProducerServiceImpl.class);
+
+    public EmailMessageProducerServiceImpl(KafkaTemplate<String, String> kafkaTemplate, ObjectMapper objectMapper) {
+        this.kafkaTemplate = kafkaTemplate;
+        this.objectMapper = objectMapper;
+        logger.info("EmailMessageProducerServiceImpl created");
+    }
+
+    @Override
+    public void sendMessage(EmailMessageTO emailMessageTO) {
+        try {
+            String message = objectMapper.writeValueAsString(emailMessageTO);
+            CompletableFuture<SendResult<String, String>> future = kafkaTemplate.send(topic, message);
+            logger.debug("Sending message: {}", message);
+            future.whenComplete((result, ex) -> {
+                if (ex == null) {
+                    logger.info("Message sent: {} with offset: {}", message, result.getRecordMetadata().offset());
+                } else {
+                    logger.error("Error sending message: {} due to: {}", message, ex.getMessage(), ex);
+                }
+            });
+        } catch (JsonProcessingException e) {
+            throw new StandardException("Error serializing EmailMessageTO: " + e.getMessage(), MessageType.DEFAULT_MESSAGE, e);
+        }
+    }
+}

--- a/src/main/java/com/umdc/smartkin/kafka/to/EmailMessageTO.java
+++ b/src/main/java/com/umdc/smartkin/kafka/to/EmailMessageTO.java
@@ -1,0 +1,48 @@
+package com.umdc.smartkin.kafka.to;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.prx.commons.util.DateUtil;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+public record EmailMessageTO(
+        @JsonProperty("template_defined_id")
+        UUID templateDefinedId,
+        @JsonProperty("user_id")
+        UUID userId,
+        @JsonProperty("from")
+        String from,
+        @JsonProperty("to")
+        List<Recipient> to,
+        @JsonProperty("cc")
+        List<Recipient> cc,
+        @JsonProperty("subject")
+        String subject,
+        @JsonProperty("body")
+        String body,
+        @JsonProperty("send_date")
+        @JsonFormat(pattern = DateUtil.PATTERN_DATE_TIME)
+        LocalDateTime sendDate,
+        @JsonProperty("params")
+        Map<String, Object> params
+) {
+
+    @Override
+    public String toString() {
+        return "EmailMessageTO{" +
+                "template_defined_id='" + templateDefinedId + '\'' +
+                ", user_id='" + userId + '\'' +
+                ", from='" + from + '\'' +
+                ", to=" + to +
+                ", cc=" + cc +
+                ", subject='" + subject + '\'' +
+                ", body='" + body + '\'' +
+                ", send_date='" + sendDate + '\'' +
+                ", params=" + params +
+                '}';
+    }
+}

--- a/src/main/java/com/umdc/smartkin/kafka/to/Recipient.java
+++ b/src/main/java/com/umdc/smartkin/kafka/to/Recipient.java
@@ -1,0 +1,17 @@
+package com.umdc.smartkin.kafka.to;
+
+public record Recipient(
+        String name,
+        String email,
+        String alias
+) {
+
+    @Override
+    public String toString() {
+        return "Recipient{" +
+                "name='" + name + '\'' +
+                ", email='" + email + '\'' +
+                ", alias='" + alias + '\'' +
+                '}';
+    }
+}

--- a/src/main/java/com/umdc/smartkin/mapper/ConfirmCodeMapper.java
+++ b/src/main/java/com/umdc/smartkin/mapper/ConfirmCodeMapper.java
@@ -1,0 +1,34 @@
+package com.umdc.smartkin.mapper;
+
+import com.umdc.smartkin.api.v1.to.ConfirmCodeRequest;
+import com.umdc.smartkin.client.mercury.to.VerificationCodeRequest;
+import org.mapstruct.*;
+
+import java.util.UUID;
+
+@Mapper(
+        // Specifies that the mapper should be a Spring bean.
+        componentModel = MappingConstants.ComponentModel.SPRING,
+        uses = {ConfirmCodeRequest.class, VerificationCodeRequest.class}
+)
+@MapperConfig(
+        // Specifies that the mapper should fail if there are any unmapped properties.
+        unmappedSourcePolicy = ReportingPolicy.IGNORE,
+        // Specifies that the mapper should fail if there are any unmapped properties.
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface ConfirmCodeMapper {
+
+    /// Maps a ConfirmCodeRequest to a VerificationCodeRequest.
+    ///
+    /// @param confirmCodeRequest the ConfirmCodeRequest to map
+    /// @return the VerificationCodeRequest
+    /// @see ConfirmCodeRequest
+    /// @see VerificationCodeRequest
+    /// @see ConfirmCodeMapper
+    @Mapping(target = "userId", source = "confirmCodeRequest.userId")
+    @Mapping(target = "code", source = "confirmCodeRequest.verificationCode")
+    @Mapping(target = "applicationId", source = "applicationId")
+    VerificationCodeRequest toVerificationCodeRequest(ConfirmCodeRequest confirmCodeRequest, UUID applicationId);
+
+}

--- a/src/main/java/com/umdc/smartkin/mapper/GetUserMapper.java
+++ b/src/main/java/com/umdc/smartkin/mapper/GetUserMapper.java
@@ -1,0 +1,87 @@
+package com.umdc.smartkin.mapper;
+
+import com.prx.commons.general.pojo.Application;
+import com.prx.commons.general.pojo.Contact;
+import com.prx.commons.general.pojo.Person;
+import com.prx.commons.general.pojo.Role;
+import com.umdc.smartkin.api.v1.to.GetUserResponse;
+import com.umdc.smartkin.client.backbone.to.BackboneUserGetResponse;
+import org.mapstruct.*;
+
+import java.util.List;
+import java.util.Objects;
+import java.util.Set;
+import java.util.UUID;
+
+@Mapper(
+        // Specifies that the mapper should be a Spring bean.
+        componentModel = MappingConstants.ComponentModel.SPRING,
+        uses = {BackboneUserGetResponse.class, GetUserResponse.class}
+)
+@MapperConfig(
+        // Specifies that the mapper should fail if there are any unmapped properties.
+        unmappedSourcePolicy = ReportingPolicy.IGNORE,
+        // Specifies that the mapper should fail if there are any unmapped properties.
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface GetUserMapper {
+
+    /// Maps a BackboneUserGetResponse to a UseGetResponse.
+    ///
+    /// @param backboneUserGetResponse the BackboneUserGetResponse to map
+    /// @return the UseGetResponse
+    /// @see BackboneUserGetResponse
+    /// @see GetUserResponse
+    /// @see GetUserMapper
+    @Mapping(target = "id", source = "backboneUserGetResponse.id")
+    @Mapping(target = "alias", source = "backboneUserGetResponse.alias")
+    @Mapping(target = "email", source = "backboneUserGetResponse.email")
+    @Mapping(target = "firstName", source = "backboneUserGetResponse.person.firstName")
+    @Mapping(target = "middleName", source = "backboneUserGetResponse.person.middleName")
+    @Mapping(target = "lastName", source = "backboneUserGetResponse.person.lastName")
+    @Mapping(target = "profileImageRef", source = "profileImageRef")
+    @Mapping(target = "updatedAt", source = "backboneUserGetResponse.lastUpdate")
+    @Mapping(target = "createdAt", source = "backboneUserGetResponse.createdDate")
+    @Mapping(target = "dateOfBirth", source = "backboneUserGetResponse.person.birthdate")
+    @Mapping(target = "phoneId", expression = "java(getContactId(backboneUserGetResponse.person()))")
+    @Mapping(target = "phoneNumber", expression = "java(getPhone(backboneUserGetResponse.person()))")
+    @Mapping(target = "status", source = "backboneUserGetResponse.active")
+    @Mapping(target = "roleId", expression = "java(getRoleId(backboneUserGetResponse))")
+    @Mapping(target = "applicationId", expression = "java(getApplicationId(backboneUserGetResponse))")
+    GetUserResponse fromBackbone(BackboneUserGetResponse backboneUserGetResponse, String profileImageRef);
+
+    default UUID getRoleId(BackboneUserGetResponse backboneUserGetResponse) {
+        List<Role> roles = backboneUserGetResponse.roles();
+        if (Objects.nonNull(roles) && !roles.isEmpty()) {
+            return roles.stream().map(Role::getId).filter(Objects::nonNull).findFirst().orElse(null);
+        }
+        return null;
+    }
+
+    default UUID getApplicationId(BackboneUserGetResponse backboneUserGetResponse) {
+        List<Application> applications = backboneUserGetResponse.applications();
+        if (Objects.nonNull(applications) && !applications.isEmpty()) {
+            return applications.stream().map(Application::getId).filter(Objects::nonNull).findFirst().orElse(null);
+        }
+        return null;
+    }
+
+    default String getPhone(Person person) {
+        if (Objects.nonNull(person)) {
+            return person.getContacts().stream()
+                    .filter(contact -> contact.getContactType().getName().equalsIgnoreCase("Phone"))
+                    .findFirst().orElse(new Contact()).getContent();
+        }
+        return "";
+    }
+
+    default UUID getContactId(Person person) {
+        if (Objects.nonNull(person)) {
+            return person.getContacts().stream()
+                    .filter(contact -> contact.getContactType().getName().equalsIgnoreCase("Phone"))
+                    .findFirst().orElse(new Contact()).getId();
+        }
+        return null;
+    }
+
+}

--- a/src/main/java/com/umdc/smartkin/mapper/PutUserMapper.java
+++ b/src/main/java/com/umdc/smartkin/mapper/PutUserMapper.java
@@ -35,7 +35,7 @@ public interface PutUserMapper {
         return List.of(new BackboneUserUpdateRequest.Contact(
                 request.phoneId(),
                 request.phoneNumber(),
-                new BackboneUserUpdateRequest.ContactType(UUID.fromString("61ed9501-bee2-4391-8376-91307ae02a48")),
+                new BackboneUserUpdateRequest.ContactType(UUID.fromString(CONTACT_TYPE_PHONE_UUID)),
                 true
         ));
     }

--- a/src/main/java/com/umdc/smartkin/mapper/PutUserMapper.java
+++ b/src/main/java/com/umdc/smartkin/mapper/PutUserMapper.java
@@ -1,0 +1,43 @@
+package com.umdc.smartkin.mapper;
+
+import com.prx.commons.services.config.mapper.MapperAppConfig;
+import com.umdc.smartkin.api.v1.to.PutUserRequest;
+import com.umdc.smartkin.client.backbone.to.BackboneUserUpdateRequest;
+import org.mapstruct.Mapper;
+import org.mapstruct.Mapping;
+
+import java.util.List;
+import java.util.UUID;
+
+/**
+ * Mapper interface for converting PatchUserRequest to BackboneUserUpdateRequest.
+ */
+@Mapper(
+        // Specifies the configuration class to use for this mapper.
+        config = MapperAppConfig.class
+)
+public interface PutUserMapper {
+
+    @Mapping(target = "application", source = "applicationId")
+    @Mapping(target = "active", source = "request.active")
+    @Mapping(target = "roleIds", source = "request.roleIds")
+    @Mapping(target = "displayName", source = "request.displayName")
+    @Mapping(target = "notificationSms", source = "request.notificationSms")
+    @Mapping(target = "notificationEmail", source = "request.notificationEmail")
+    @Mapping(target = "privacyDataOutActive", source = "request.privacyDataOutActive")
+    @Mapping(target = "contacts", expression = "java(mapContacts(request))")
+    BackboneUserUpdateRequest toBackbone(UUID applicationId, PutUserRequest request);
+
+    /**
+     * Helper method to map person fields from PatchUserRequest to BackboneUserUpdateRequest.Person.
+     */
+    default List<BackboneUserUpdateRequest.Contact> mapContacts(PutUserRequest request) {
+        return List.of(new BackboneUserUpdateRequest.Contact(
+                request.phoneId(),
+                request.phoneNumber(),
+                new BackboneUserUpdateRequest.ContactType(UUID.fromString("61ed9501-bee2-4391-8376-91307ae02a48")),
+                true
+        ));
+    }
+}
+

--- a/src/main/java/com/umdc/smartkin/mapper/UserCreateMapper.java
+++ b/src/main/java/com/umdc/smartkin/mapper/UserCreateMapper.java
@@ -54,7 +54,7 @@ public interface UserCreateMapper {
         if(!userCreateRequest.phoneNumber().isBlank()) {
             var contact  = new Contact();
             var contactType = new ContactType();
-            contactType.setId(UUID.fromString("61ed9501-bee2-4391-8376-91307ae02a48"));
+            contactType.setId(PHONE_CONTACT_TYPE_ID);
             contact.setContent(userCreateRequest.phoneNumber());
             contact.setActive(true);
             contact.setContactType(contactType);

--- a/src/main/java/com/umdc/smartkin/mapper/UserCreateMapper.java
+++ b/src/main/java/com/umdc/smartkin/mapper/UserCreateMapper.java
@@ -1,0 +1,67 @@
+package com.umdc.smartkin.mapper;
+
+import com.prx.commons.general.pojo.Contact;
+import com.prx.commons.general.pojo.ContactType;
+import com.prx.commons.general.pojo.Person;
+import com.umdc.smartkin.api.v1.to.UserCreateRequest;
+import com.umdc.smartkin.api.v1.to.UserCreateResponse;
+import com.umdc.smartkin.client.backbone.to.BackboneUserCreateRequest;
+import com.umdc.smartkin.client.backbone.to.BackboneUserCreateResponse;
+import org.mapstruct.*;
+
+import java.util.List;
+import java.util.UUID;
+
+@Mapper(
+        // Specifies that the mapper should be a Spring bean.
+        componentModel = MappingConstants.ComponentModel.SPRING,
+        uses = {BackboneUserCreateRequest.class, UserCreateRequest.class}
+)
+@MapperConfig(
+        // Specifies that the mapper should fail if there are any unmapped properties.
+        unmappedSourcePolicy = ReportingPolicy.IGNORE,
+        // Specifies that the mapper should fail if there are any unmapped properties.
+        unmappedTargetPolicy = ReportingPolicy.IGNORE
+)
+public interface UserCreateMapper {
+
+    @Mapping(target = "id", ignore = true)
+    @Mapping(target = "active", ignore = true)
+    @Mapping(target = "alias", source = "alias")
+    @Mapping(target = "applicationId", source = "applicationId")
+    @Mapping(target = "email", source = "userCreateRequest.email")
+    @Mapping(target = "password", source = "userCreateRequest.password")
+    @Mapping(target = "person", expression = "java(getPerson(userCreateRequest))")
+    BackboneUserCreateRequest toBackbone(UserCreateRequest userCreateRequest, UUID applicationId, UUID roleId, String alias);
+
+    @Mapping(target = "id", source = "id")
+    @Mapping(target = "alias", source = "alias")
+    @Mapping(target = "active", source = "active")
+    @Mapping(target = "email", source = "email")
+    @Mapping(target = "roleId", source = "roleId")
+    @Mapping(target = "personId", source = "personId")
+    @Mapping(target = "applicationId", source = "applicationId")
+    UserCreateResponse fromBackbone(BackboneUserCreateResponse backboneUserCreateResponse);
+
+    default Person getPerson(UserCreateRequest userCreateRequest) {
+        var person = new Person();
+        person.setFirstName(userCreateRequest.firstname());
+        person.setLastName(userCreateRequest.lastname());
+        person.setBirthdate(userCreateRequest.dateOfBirth());
+        person.setGender("N");
+        person.setMiddleName("");
+
+        if(!userCreateRequest.phoneNumber().isBlank()) {
+            var contact  = new Contact();
+            var contactType = new ContactType();
+            contactType.setId(UUID.fromString("61ed9501-bee2-4391-8376-91307ae02a48"));
+            contact.setContent(userCreateRequest.phoneNumber());
+            contact.setActive(true);
+            contact.setContactType(contactType);
+            person.setContacts(List.of(contact));
+        }
+
+        return person;
+    }
+
+}

--- a/src/main/java/com/umdc/smartkin/mapper/UserCreateMapper.java
+++ b/src/main/java/com/umdc/smartkin/mapper/UserCreateMapper.java
@@ -48,7 +48,7 @@ public interface UserCreateMapper {
         person.setFirstName(userCreateRequest.firstname());
         person.setLastName(userCreateRequest.lastname());
         person.setBirthdate(userCreateRequest.dateOfBirth());
-        person.setGender("N");
+        person.setGender(DEFAULT_GENDER);
         person.setMiddleName("");
 
         if(!userCreateRequest.phoneNumber().isBlank()) {

--- a/src/main/resources/bootstrap.yml
+++ b/src/main/resources/bootstrap.yml
@@ -52,7 +52,7 @@ spring:
   ssl:
     bundle:
       jks:
-        directory-security:
+        smartkin-security:
           keystore:
             location: classpath:${SSL_KEYSTORE_LOCATION}
             password: ${SSL_KEYSTORE_PASSWORD}


### PR DESCRIPTION
### Summary

This pull request introduces several new features and improvements:

- **Implemented User Management APIs:**
  - Added `UserController` and `UserRegisterController` for handling user management and registration operations.
  - Created service implementations (`UserServiceImpl`, `UserRegisterServiceImpl`) and related DTOs for streamlined request and response management.
  - Updated Feign clients (`MercuryClient`, `BackboneClient`) for external service communication.

- **Refactored Package Structure:**
  - Changed package naming convention from `com.umdevcreative` to `com.umdc` for project consistency.

- **Introduced JPA Entities and Repositories:**
  - Added key JPA entities (`UserEntity`, `ActivityEntity`, etc.) and their corresponding repositories.
  - Enhanced documentation via `package-info.java` files.

- **Backend Enhancements:**
  - Introduced authentication utilities (`AuthServiceImpl`, `JwtUtil`).
  - Defined additional DTOs for feature operations (e.g., `VerificationCodeRequest`, `PostProfileImageResponse`).

This update strengthens the backend's maintainability and functionality.