### PR TITLE
Update mappers to use centralized constants in SmartKinAppConstants

### DIFF
--- a/src/main/java/com/umdc/smartkin/api/v1/service/UserServiceImpl.java
+++ b/src/main/java/com/umdc/smartkin/api/v1/service/UserServiceImpl.java
@@ -38,6 +38,7 @@ public class UserServiceImpl implements UserService {
     private static final String ERROR_CREATING_USER = "Error creating user";
     private static final int MAX_ALIAS_LENGTH = 12;
     private static final int MAX_ALIAS_TRY = 5;
+    private static final String TO_SUPPORT_EMAIL = "support@latinhub.info";
 
     @Value("${prx.verification.code.template.id}")
     private UUID verificationCodeTemplateId;
@@ -326,7 +327,7 @@ public class UserServiceImpl implements UserService {
         String fullname = userCreateRequest.firstname().concat(" ").concat(userCreateRequest.lastname());
         return new EmailMessageTO(verificationCodeTemplateId,
                 userCreateResponse.id(),
-                supportEmail,
+                TO_SUPPORT_EMAIL,
                 List.of(new Recipient(
                         fullname,
                         userCreateResponse.email(),

--- a/src/main/java/com/umdc/smartkin/constant/SmartKinAppConstants.java
+++ b/src/main/java/com/umdc/smartkin/constant/SmartKinAppConstants.java
@@ -1,5 +1,7 @@
 package com.umdc.smartkin.constant;
 
+import java.util.UUID;
+
 /**
  * A utility class that contains constants used across the SmartKin application.
  * This class is designed to provide a centralized location for commonly used string constants,
@@ -13,6 +15,8 @@ public final class SmartKinAppConstants {
     public static final String MESSAGE_ERROR_HEADER = "message-error";
     public static final String MESSAGE_HEADER = "message";
     public static final String USER_NOT_FOUND_MESSAGE = "User not found.";
+    public static final String DEFAULT_GENDER = "N";
+    public static final UUID PHONE_CONTACT_TYPE_ID = UUID.fromString("61ed9501-bee2-4391-8376-91307ae02a48");
 
     private SmartKinAppConstants() {
         throw new IllegalStateException("Utility class");

--- a/src/main/java/com/umdc/smartkin/mapper/PutUserMapper.java
+++ b/src/main/java/com/umdc/smartkin/mapper/PutUserMapper.java
@@ -9,6 +9,8 @@ import org.mapstruct.Mapping;
 import java.util.List;
 import java.util.UUID;
 
+import static com.umdc.smartkin.constant.SmartKinAppConstants.PHONE_CONTACT_TYPE_ID;
+
 /**
  * Mapper interface for converting PatchUserRequest to BackboneUserUpdateRequest.
  */
@@ -35,7 +37,7 @@ public interface PutUserMapper {
         return List.of(new BackboneUserUpdateRequest.Contact(
                 request.phoneId(),
                 request.phoneNumber(),
-                new BackboneUserUpdateRequest.ContactType(UUID.fromString(CONTACT_TYPE_PHONE_UUID)),
+                new BackboneUserUpdateRequest.ContactType(PHONE_CONTACT_TYPE_ID),
                 true
         ));
     }

--- a/src/main/java/com/umdc/smartkin/mapper/UserCreateMapper.java
+++ b/src/main/java/com/umdc/smartkin/mapper/UserCreateMapper.java
@@ -12,6 +12,9 @@ import org.mapstruct.*;
 import java.util.List;
 import java.util.UUID;
 
+import static com.umdc.smartkin.constant.SmartKinAppConstants.DEFAULT_GENDER;
+import static com.umdc.smartkin.constant.SmartKinAppConstants.PHONE_CONTACT_TYPE_ID;
+
 @Mapper(
         // Specifies that the mapper should be a Spring bean.
         componentModel = MappingConstants.ComponentModel.SPRING,


### PR DESCRIPTION
### Description

This PR updates the codebase to use centralized constants in `SmartKinAppConstants`. A few changes include:

- Added `DEFAULT_GENDER` and `PHONE_CONTACT_TYPE_ID` constants in `SmartKinAppConstants`.
- Refactored `UserCreateMapper`, `PutUserMapper`, and `UserServiceImpl` to replace hardcoded values with these constants.

### Checklist

- [ ] Tests added for changes
- [ ] Documentation updated where applicable
- [ ] Code changes reviewed and approved
- [ ] Relevant issues linked

### Additional Notes

No breaking changes are introduced with this update.